### PR TITLE
[t127823] Applying GE inheritance on products:

### DIFF
--- a/attribute_set/models/attribute_set_owner.py
+++ b/attribute_set/models/attribute_set_owner.py
@@ -26,10 +26,18 @@ class AttributeSetOwnerMixin(models.AbstractModel):
     def _build_attribute_eview(self):
         """Override Attribute's method _build_attribute_eview() to build an
         attribute eview with the mixin model's attributes"""
-        domain = [
-            ("model_id.model", "=", self._name),
-            ("attribute_set_ids", "!=", False),
-        ]
+        if self._name != 'product.product':
+            domain = [
+                ("model_id.model", "=", self._name),
+                ("attribute_set_ids", "!=", False),
+            ]
+        else:
+            domain = [
+                ("attribute_set_ids", "!=", False),
+                '|',
+                ("model_id.model", "=", self._name),
+                ("model_id.model", "=", "product.template"),
+            ]
         if not self._context.get("include_native_attribute"):
             domain.append(("nature", "=", "custom"))
 

--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -37,7 +37,19 @@ class ProductTemplate(models.Model):
         if not vals.get("attribute_set_id") and vals.get("categ_id"):
             category = self.env["product.category"].browse(vals["categ_id"])
             vals["attribute_set_id"] = category.attribute_set_id.id
-        return super().create(vals)
+        product_template = super().create(vals)
+        if product_template.attribute_set_id:
+            vals_to_write = {'attribute_set_id': product_template.attribute_set_id.id}
+            attributes = self.env["attribute.attribute"].search([
+                ("model_id.model", "=", self._name),
+                ("attribute_set_ids", "!=", False),
+            ])
+            for attribute in attributes:
+                vals_to_write[attribute.name] = product_template[attribute.name]
+            product_template.product_variant_ids.write(
+                self.env['product.product']._convert_to_write(vals_to_write)
+            )
+        return product_template
 
     def write(self, vals):
         if not vals.get("attribute_set_id") and vals.get("categ_id"):


### PR DESCRIPTION
 - Sprint 12 changes: The OCA Module allows to create non variant building attributes on product.template or product.product. So far there is no inheritance from the product.template to the variant. Changes to create the record in the product.template and then inherit it to the product.product. The user must still be able to adjust it manually on the variant but no inheritance up.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127823">[t127823] non variant forming attributes on product.product</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>product_attribute_set</td><td>.py</td></tr>
<tr><td>attribute_set</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->