### PR TITLE
[t127823] Applying GE inheritance on products:

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- /!\ do not modify above this line -->
 
-# odoo-pim
+# odoo-pim: Fully customized for GE project
 
 TODO: add repo description.
 

--- a/attribute_set/models/attribute_set_owner.py
+++ b/attribute_set/models/attribute_set_owner.py
@@ -26,18 +26,10 @@ class AttributeSetOwnerMixin(models.AbstractModel):
     def _build_attribute_eview(self):
         """Override Attribute's method _build_attribute_eview() to build an
         attribute eview with the mixin model's attributes"""
-        if self._name != 'product.product':
-            domain = [
-                ("model_id.model", "=", self._name),
-                ("attribute_set_ids", "!=", False),
-            ]
-        else:
-            domain = [
-                ("attribute_set_ids", "!=", False),
-                '|',
-                ("model_id.model", "=", self._name),
-                ("model_id.model", "=", "product.template"),
-            ]
+        domain = [
+            ("model_id.model", "=", self._name),
+            ("attribute_set_ids", "!=", False),
+        ]
         if not self._context.get("include_native_attribute"):
             domain.append(("nature", "=", "custom"))
 

--- a/product_attribute_set/models/__init__.py
+++ b/product_attribute_set/models/__init__.py
@@ -1,2 +1,6 @@
 from . import product_category
 from . import product
+from . import attribute_set
+from . import attribute_group
+from . import attribute_attribute
+from . import attribute_option

--- a/product_attribute_set/models/attribute_attribute.py
+++ b/product_attribute_set/models/attribute_attribute.py
@@ -1,0 +1,111 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://bt-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+from odoo import api, fields, models
+
+
+class AttributeAttribute(models.Model):
+    _inherit = "attribute.attribute"
+
+    linked_attribute_attribute_id = fields.Many2one(
+        'attribute.attribute', readonly=True, copy=False)
+
+    def copy_to_model(self, new_model_id):
+        """Returns a new record with the same fields and group in the new model"""
+        self.ensure_one()
+        if self.nature == 'custom' and self.model_id.model == 'product.template':
+            if self.attribute_group_id:
+                if self.attribute_group_id.linked_attribute_group_id:
+                    attribute_group_id = \
+                        self.attribute_group_id.linked_attribute_group_id.id
+                else:
+                    attribute_group_id = \
+                        self.attribute_group_id.copy_to_model(new_model_id).id
+            else:
+                attribute_group_id = None
+            new_field = self.env['ir.model.fields'].search(
+                [('model_id', '=', new_model_id),
+                 ('name', '=', self.field_id.name)],
+                limit=1,
+            )
+            if new_field:
+                new_attribute = self.create({
+                    'nature': 'native',
+                    'model_id': new_model_id,
+                    'field_id': new_field.id,
+                    'attribute_group_id': attribute_group_id,
+                    'sequence': self.sequence,
+                    'required_on_views': self.required_on_views,
+                    'attribute_set_ids': [
+                        (6, 0,
+                         self.attribute_set_ids.mapped(
+                             'linked_attribute_set_id.id')),
+                    ],
+                    'option_ids': None,
+                    'attribute_type': self.attribute_type,
+                    'serialized': self.serialized,
+                })
+                self.env.cr.execute(
+                    "UPDATE ir_model_fields "
+                    "SET state='manual', related=null, compute=null "
+                    "WHERE id = %s",
+                    (new_attribute.field_id.id, )
+                )
+                new_attribute.invalidate_cache()
+                new_attribute.write({
+                    'nature': 'custom',
+                    'store': True,
+                })
+                self.write({
+                    'linked_attribute_attribute_id': new_attribute.id,
+                })
+                for option in self.option_ids:
+                    option.copy_to_model()
+                return new_attribute
+
+        return None
+
+    @api.model
+    def create(self, vals):
+        """Creates a new field in product.product if we create it for
+        product.template"""
+        attribute_attribute = super(
+            AttributeAttribute, self.with_context(ge_pim=True)).create(vals)
+        if attribute_attribute.model_id.model == 'product.template':
+            attribute_attribute.copy_to_model(
+                self.env.ref("product.model_product_product").id)
+        return attribute_attribute
+
+    def write(self, vals):
+        """Updates the linked attributes if the record updated has any"""
+        ret = super().write(vals)
+        linked_attributes = self.mapped('linked_attribute_attribute_id')
+        if linked_attributes:
+            if 'linked_attribute_attribute_id' in vals:
+                del vals['linked_attribute_attribute_id']
+            if 'attribute_set_ids' in vals:
+                self.ensure_one()  # for simplicity, otherwise refactor
+                vals['attribute_set_ids'] = [
+                    (6, 0,
+                     self.attribute_set_ids.mapped('linked_attribute_set_id.id')),
+                ]
+            if 'option_ids' in vals:
+                del vals['option_ids']
+                self.ensure_one()  # for simplicity, otherwise refactor
+                for option in self.option_ids:
+                    if not option.linked_attribute_option_id:
+                        option.copy_to_model()
+            if vals:
+                linked_attributes.write(vals)
+        return ret
+
+    def unlink(self):
+        """Deletes the linked attributes if the record updated has any"""
+        linked_attributes = self.mapped('linked_attribute_attribute_id')
+        if linked_attributes:
+            linked_attributes.unlink()
+        return super().unlink()

--- a/product_attribute_set/models/attribute_group.py
+++ b/product_attribute_set/models/attribute_group.py
@@ -1,0 +1,54 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://bt-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+from odoo import api, fields, models
+
+
+class AttributeGroup(models.Model):
+    _inherit = "attribute.group"
+
+    linked_attribute_group_id = fields.Many2one(
+        'attribute.group', readonly=True, copy=False)
+
+    def copy_to_model(self, new_model_id):
+        """Returns a new record with the same fields in the new model"""
+        self.ensure_one()
+        new_attribute_group = self.copy({
+            'model_id': new_model_id,
+        })
+        self.write({
+            'linked_attribute_group_id': new_attribute_group.id,
+        })
+        return new_attribute_group
+
+    @api.model
+    def create(self, vals):
+        """Creates a new field in product.product if we create it for
+        product.template"""
+        attribute_group = super().create(vals)
+        if attribute_group.model_id.model == 'product.template':
+            attribute_group.copy_to_model(
+                self.env.ref("product.model_product_product").id)
+        return attribute_group
+
+    def write(self, vals):
+        """Updates the linked groups if the record updated has any"""
+        ret = super().write(vals)
+        linked_groups = self.mapped('linked_attribute_group_id')
+        if linked_groups:
+            if 'linked_attribute_group_id' in vals:
+                del vals['linked_attribute_group_id']
+            if vals:
+                linked_groups.write(vals)
+        return ret
+
+    def unlink(self):
+        """Deletes the linked groups if the record updated has any"""
+        linked_groups = self.mapped('linked_attribute_group_id')
+        if linked_groups:
+            linked_groups.unlink()
+        return super().unlink()

--- a/product_attribute_set/models/attribute_option.py
+++ b/product_attribute_set/models/attribute_option.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://bt-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+from odoo import fields, models
+
+
+class AttributeOption(models.Model):
+    _inherit = "attribute.option"
+
+    linked_attribute_option_id = fields.Many2one(
+        'attribute.option', readonly=True, copy=False)
+
+    def copy_to_model(self):
+        """Returns a new record with the same fields in the new model"""
+        self.ensure_one()
+        if self.attribute_id.linked_attribute_attribute_id:
+            new_attribute_option = self.copy({
+                'attribute_id': self.attribute_id.linked_attribute_attribute_id.id,
+            })
+            self.write({
+                'linked_attribute_option_id': new_attribute_option.id,
+            })
+            return new_attribute_option
+        return None
+
+    def write(self, vals):
+        """Updates the linked groups if the record updated has any"""
+        ret = super().write(vals)
+        linked_options = self.mapped('linked_attribute_option_id')
+        if linked_options:
+            if 'linked_attribute_option_id' in vals:
+                del vals['linked_attribute_option_id']
+            if vals:
+                linked_options.write(vals)
+        return ret
+
+    def unlink(self):
+        """Deletes the linked groups if the record updated has any"""
+        linked_options = self.mapped('linked_attribute_option_id')
+        if linked_options:
+            linked_options.unlink()
+        return super().unlink()

--- a/product_attribute_set/models/attribute_set.py
+++ b/product_attribute_set/models/attribute_set.py
@@ -1,0 +1,58 @@
+##############################################################################
+# Copyright (c) 2022 brain-tec AG (https://bt-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+from odoo import api, fields, models
+
+
+class AttributeSet(models.Model):
+    _inherit = "attribute.set"
+
+    linked_attribute_set_id = fields.Many2one(
+        'attribute.set', readonly=True, copy=False)
+
+    def copy_to_model(self, new_model_id):
+        """Returns a new record with the same fields in the new model"""
+        self.ensure_one()
+        new_attribute_set = self.copy({
+            'attribute_ids': [
+                (6, 0,
+                 self.attribute_ids.mapped('linked_attribute_attribute_id.id')),
+            ],
+            'model_id': new_model_id,
+        })
+        self.write({
+            'linked_attribute_set_id': new_attribute_set.id,
+        })
+        return new_attribute_set
+
+    @api.model
+    def create(self, vals):
+        """Creates a new field in product.product if we create it for
+        product.template"""
+        attribute_set = super().create(vals)
+        if attribute_set.model_id.model == 'product.template':
+            attribute_set.copy_to_model(
+                self.env.ref("product.model_product_product").id)
+        return attribute_set
+
+    def write(self, vals):
+        """Updates the linked sets if the record updated has any"""
+        ret = super().write(vals)
+        linked_sets = self.mapped('linked_attribute_set_id')
+        if linked_sets:
+            if 'linked_attribute_set_id' in vals:
+                del vals['linked_attribute_set_id']
+            if vals:
+                linked_sets.write(vals)
+        return ret
+
+    def unlink(self):
+        """Deletes the linked sets if the record updated has any"""
+        linked_sets = self.mapped('linked_attribute_set_id')
+        if linked_sets:
+            linked_sets.unlink()
+        return super().unlink()

--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -10,7 +10,8 @@ class ProductTemplate(models.Model):
     """The mixin 'attribute.set.owner.mixin' override the model's fields_view_get()
     method which will replace the 'attributes_placeholder' by a group made up of all
     the product.template's Attributes.
-    Each Attribute will have a conditional invisibility depending on its Attribute Sets.
+    Each Attribute will have a conditional invisibility depending on its
+    Attribute Sets.
     """
 
     _inherit = ["product.template", "attribute.set.owner.mixin"]
@@ -37,19 +38,23 @@ class ProductTemplate(models.Model):
         if not vals.get("attribute_set_id") and vals.get("categ_id"):
             category = self.env["product.category"].browse(vals["categ_id"])
             vals["attribute_set_id"] = category.attribute_set_id.id
-        product_template = super().create(vals)
-        if product_template.attribute_set_id:
-            vals_to_write = {'attribute_set_id': product_template.attribute_set_id.id}
+        pt = super().create(vals)
+        if pt.attribute_set_id:
+            vals_to_write = {
+                'attribute_set_id':
+                    pt.attribute_set_id.linked_attribute_set_id.id,
+            }
             attributes = self.env["attribute.attribute"].search([
                 ("model_id.model", "=", self._name),
                 ("attribute_set_ids", "!=", False),
+                ("linked_attribute_attribute_id", "!=", False),
             ])
             for attribute in attributes:
-                vals_to_write[attribute.name] = product_template[attribute.name]
-            product_template.product_variant_ids.write(
+                vals_to_write[attribute.name] = pt[attribute.name]
+            pt.product_variant_ids.write(
                 self.env['product.product']._convert_to_write(vals_to_write)
             )
-        return product_template
+        return pt
 
     def write(self, vals):
         if not vals.get("attribute_set_id") and vals.get("categ_id"):

--- a/product_attribute_set/models/product_category.py
+++ b/product_attribute_set/models/product_category.py
@@ -15,7 +15,8 @@ class ProductCategory(models.Model):
     )
 
     def write(self, vals):
-        """Fill Category's products with Category's default attribute_set_id if empty"""
+        """Fill Category's products with Category's default attribute_set_id if
+        empty"""
         super().write(vals)
         for record in self:
             if vals.get("attribute_set_id"):

--- a/product_attribute_set/views/product.xml
+++ b/product_attribute_set/views/product.xml
@@ -74,14 +74,11 @@
     <record id="product_variant_easy_edit_view" model="ir.ui.view">
         <field name="name">.view.form</field>
         <field name="model">product.product</field>
-        <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
                 <notebook>
-                    <page
-                        name="product_attributes"
-                        string="Attributes"
-                    >
+                    <page name="product_attributes" string="Attributes">
                         <separator name="attributes_placeholder" />
                     </page>
                 </notebook>


### PR DESCRIPTION
 - Sprint 12 changes: The OCA Module allows to create non variant building attributes on product.template or product.product. So far there is no inheritance from the product.template to the variant. Changes to create the record in the product.template and then inherit it to the product.product. The user must still be able to adjust it manually on the variant but no inheritance up.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127823">[t127823] non variant forming attributes on product.product</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>product_attribute_set</td><td>.xml, .py</td></tr>
<tr><td>attribute_set</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->