### PR TITLE
[t127823] Applying GE inheritance on products:

### DIFF
--- a/product_attribute_set/models/product_category.py
+++ b/product_attribute_set/models/product_category.py
@@ -2,7 +2,7 @@
 # @author Benoit Guillot <benoit.guillot@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductCategory(models.Model):
@@ -13,6 +13,11 @@ class ProductCategory(models.Model):
         "Default Attribute Set",
         context={"default_model_id": "product.template"},
     )
+
+    @api.onchange('parent_id')
+    def _onchange_parent_id(self):
+        if not self.attribute_set_id and self.parent_id and self.parent_id.attribute_set_id:
+            self.attribute_set_id = self.parent_id.attribute_set_id.id
 
     def write(self, vals):
         """Fill Category's products with Category's default attribute_set_id if


### PR DESCRIPTION
 - The default attribute set to parent's if it's empty

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127823">[t127823] non variant forming attributes on product.product</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>product_attribute_set</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->