### PR TITLE
[t127823] product.category set domain on product.template

### DIFF
--- a/product_attribute_set/views/product_category.xml
+++ b/product_attribute_set/views/product_category.xml
@@ -8,7 +8,7 @@
             <field name="parent_id" position="after">
                 <field
                     name="attribute_set_id"
-                    domain="['|', ('model_id', '=', 'product.template'),('model_id', '=', 'product.product')]"
+                    domain="[('model_id', '=', 'product.template')]"
                     class="oe_inline"
                 />
             </field>


### PR DESCRIPTION
 - The customer asked us to revert the changes so the attribute set domain of product.category is only showing sets from product.template

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec.com/web#view_type=form&model=project.task&id=127823">[t127823] non variant forming attributes on product.product</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>product_attribute_set</td><td>.xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->