### PR TITLE
[t127823] Onchange category and attribute set

### DIFF
--- a/product_attribute_set/models/product.py
+++ b/product_attribute_set/models/product.py
@@ -35,9 +35,6 @@ class ProductTemplate(models.Model):
 
     @api.model
     def create(self, vals):
-        if not vals.get("attribute_set_id") and vals.get("categ_id"):
-            category = self.env["product.category"].browse(vals["categ_id"])
-            vals["attribute_set_id"] = category.attribute_set_id.id
         pt = super().create(vals)
         if pt.attribute_set_id:
             vals_to_write = {
@@ -56,16 +53,10 @@ class ProductTemplate(models.Model):
             )
         return pt
 
-    def write(self, vals):
-        if not vals.get("attribute_set_id") and vals.get("categ_id"):
-            category = self.env["product.category"].browse(vals["categ_id"])
-            vals["attribute_set_id"] = category.attribute_set_id.id
-        return super().write(vals)
-
     @api.onchange("categ_id")
     def update_att_set_onchange_categ_id(self):
         self.ensure_one()
-        if self.categ_id and not self.attribute_set_id:
+        if self.categ_id and self.categ_id.attribute_set_id and not self.attribute_set_id:
             self.attribute_set_id = self.categ_id.attribute_set_id
 
 

--- a/product_attribute_set/views/product.xml
+++ b/product_attribute_set/views/product.xml
@@ -84,7 +84,7 @@
                 </notebook>
             </xpath>
             <field name="name" position="after">
-                <field name="attribute_set_id" invisible="1"/>
+                <field name="attribute_set_id" invisible="1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
- We should only inherit the attribute to the template on create from the category to the template. What the user selects must stay, so we don't overwrite create or write methods.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec.com/web#view_type=form&model=project.task&id=127823">[t127823] non variant forming attributes on product.product</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>product_attribute_set</td><td>.py, .xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->